### PR TITLE
Fix DarkGravityWave: Use only same block type

### DIFF
--- a/src/main.h
+++ b/src/main.h
@@ -88,6 +88,7 @@ static const int64_t nGenesisHeight = 0;
 static const int64_t nBlocktimeregress = 125000; // Retard block time
 /** Espers system patch fork*/
 static const int64_t nGravityFork = 615000; // Light Espers chain fork for DarkGravityWave and block time redux.
+static const int64_t nGravityFixFork = 999999;
 /** Reserve Phase start block */ 
 static const int64_t nReservePhaseStart = 10;
 /** Reserve Phase end block */ 


### PR DESCRIPTION
I created a copy from DarkGravityWave function, and add the fix to in:
It use the GetLastBlockIndex() when jump to pprev block.

The fix fork is set to 999999 block, you can change it to any value.